### PR TITLE
Changed mainPath to .config/indiepkg

### DIFF
--- a/config.go
+++ b/config.go
@@ -6,7 +6,7 @@ import (
 	"github.com/pelletier/go-toml/v2"
 )
 
-var mainPath string = home + ".indiepkg/"
+var mainPath string = home + ".config/indiepkg/"
 var srcPath string = mainPath + "data/package_src/"
 var tmpSrcPath string = mainPath + "tmp/package_src/"
 var infoPath string = mainPath + "data/installed_packages/"


### PR DESCRIPTION
Hello, config files should normally be located in `~/.config` and not a dedicated folder in the users home.
So I changed the `mainPath` from `.indiepkg` to `.config/indiepkg`.
Greetings