### PR TITLE
Try to follow XDG specifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ make install
 Currently, there is no uninstallation script, but you can super easily uninstall IndiePKG by running these commands.
 
 ```bash
-rm -rf ~/.indiepkg
+rm -rf ~/.local/share/indiepkg
 rm ~/.local/bin/indiepkg
 ```
 

--- a/config.go
+++ b/config.go
@@ -1,13 +1,14 @@
 package main
 
 import (
+	"os"
 	"strings"
 
 	"github.com/pelletier/go-toml/v2"
 )
 
 var (
-	mainPath        string = home + ".indiepkg/"
+	mainPath        string = chooseDataDir()
 	srcPath         string = mainPath + "data/package_src/"
 	tmpSrcPath      string = mainPath + "tmp/package_src/"
 	infoPath        string = mainPath + "data/installed_packages/"
@@ -104,4 +105,19 @@ func loadConfig() {
 	if !strings.HasSuffix(config.Paths.Prefix, "/") { // If doesn't end with a /, add one
 		config.Paths.Prefix += "/"
 	}
+}
+
+// chooseDataDir returns the best directory to store data based on $INDIEPKG_DATADIR and $XDG_DATA_HOME,
+// using ~/.local/share/indiepkg as the default if neither is set.
+func chooseDataDir() string {
+	home, _ := os.UserHomeDir()
+	remEnv := os.Getenv("INDIEPKG_DATADIR")
+	if remEnv != "" {
+		return remEnv
+	}
+	dataHome := os.Getenv("XDG_DATA_HOME")
+	if dataHome != "" {
+		return dataHome + "/indiepkg/"
+	}
+	return home + "/.local/share/indiepkg/"
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,5 +1,15 @@
 #!/usr/bin/env bash
 
+if [ -z "$INDIEPKG_DATADIR" ]
+then
+    if [ -n "$XDG_DATA_HOME" ]
+    then
+        INDIEPKG_DATADIR="$XDG_DATA_HOME/indiepkg"
+    else
+        INDIEPKG_DATADIR="$HOME/.local/share/indiepkg"
+    fi
+fi
+
 log() {
     echo -e "$1[.]${RESET} $2"
 }
@@ -58,13 +68,13 @@ chap_log "$MAGENTA=>" "Installing IndiePKG"
 chap_log "$BLUE==>" "Cloning source code"
 
 log "$CYAN" "Cloning source code..."
-mkdir "$HOME/.indiepkg/"
-git clone -b testing https://github.com/talwat/indiepkg.git "$HOME/.indiepkg/src"
+mkdir "$INDIEPKG_DATADIR"
+git clone -b testing https://github.com/talwat/indiepkg.git "$INDIEPKG_DATADIR/src"
 
 chap_log "$BLUE==>" "Compiling source code"
 
 log "$CYAN" "Compiling source code..."
-cd "$HOME/.indiepkg/src" || exit 1
+cd "$INDIEPKG_DATADIR/src" || exit 1
 make
 
 chap_log "$BLUE==>" "Installing"


### PR DESCRIPTION
Instead of having a `~/.indiepkg` directory that clutters one's home, the data dir is put in a place that try to respect the XDG specifications.